### PR TITLE
Use 'celsius' term consistently throughout code and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://www.tindie.com/products/miceuz/i2c-soil-moisture-sensor/
 
 * Get soil moisture in percent (requires calibration) or capacitance value.
 
-* Several temperature scales to choose from. Celcius, Farenheit and Kelvin.
+* Several temperature scales to choose from. Celsius, Farenheit and Kelvin.
 
 * Offset to calibrate the temperature sensor.
 
@@ -80,7 +80,7 @@ Make the calibration in the environment that you intend to use the sensor.
 | address | int | 0x20 | 3-119 or 0x03-0x77 | I2C address
 | min_moist | int| False | | Set to a calibrated value to enable moist_percent |
 | max_moist | int | False | | Set to a calibrated value to enable moist_percent
-| temp_scale | str | 'celcius' | 'celcius', 'farenheit', 'kelvin' | Temperature scale to use. |
+| temp_scale | str | 'celsius' | 'celsius', 'farenheit', 'kelvin' | Temperature scale to use. |
 | temp_offset | float | 0 | | Offset for calibrating temperature.
 | read_temp | bool | True | True or False | Enable or disable temp measurements.|
 | read_moist | bool | True | True or False | Enable or disable moisture measurements. |

--- a/chirp.py
+++ b/chirp.py
@@ -251,7 +251,7 @@ class Chirp(object):
 
     def _read_temp(self):
         """To read temperature, read 2 bytes from register 5. Returns degrees
-        in celcius with one decimal. Adjusted for temperature offset
+        in celsius with one decimal. Adjusted for temperature offset
 
         Returns:
             float: Temperature in selected scale (temp_scale)
@@ -273,18 +273,18 @@ class Chirp(object):
         # The chirp sensor returns an integer. But the return measurement is
         # actually a float with one decimal. Needs to be converted to float by
         # dividing by ten. And adjusted for temperature offset (if used).
-        celcius = round(((measurement / 10) + self.temp_offset), 1)
+        celsius = round(((measurement / 10) + self.temp_offset), 1)
 
         # Check which temperature scale to return the measurement in.
         if self.temp_scale == 'celsius':
-            return celcius
+            return celsius
         elif self.temp_scale == 'farenheit':
             # °F = (°C × 9/5) + 32
-            farenheit = (celcius * 9 / 5) + 32
+            farenheit = (celsius * 9 / 5) + 32
             return farenheit
         elif self.temp_scale == 'kelvin':
             # K = °C + 273.15
-            kelvin = celcius + 273.15
+            kelvin = celsius + 273.15
             return kelvin
         else:
             raise ValueError(


### PR DESCRIPTION
Replace occurrences of 'celcius' with the correct form 'celsius'

According to https://en.wikipedia.org/wiki/Celcius_(disambiguation):
> Celcius is a common misspelling of Celsius,
> a scale and unit of measurement for temperature

Fix https://github.com/ageir/chirp-rpi/issues/2

Signed-off-by: Gianpaolo Macario <gacario@gmail.com>